### PR TITLE
Checkout SDK: keyboard fix, OTP dial-shortcode, OTP endpoint + post-OTP payment flow, bill-prompt dialog

### DIFF
--- a/.idea/AndroidProjectSystem.xml
+++ b/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,123 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JetCodeStyleSettings>
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </JetCodeStyleSettings>
+    <codeStyleSettings language="XML">
+      <option name="FORCE_REARRANGE_MODE" value="1" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+      <arrangement>
+        <rules>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:android</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>ANDROID_ATTRIBUTE_ORDER</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>.*</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+        </rules>
+      </arrangement>
+    </codeStyleSettings>
+    <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/deviceManager.xml
+++ b/.idea/deviceManager.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DeviceTable">
+    <option name="columnSorters">
+      <list>
+        <ColumnSorterState>
+          <option name="column" value="Name" />
+          <option name="order" value="ASCENDING" />
+        </ColumnSorterState>
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/markdown.xml
+++ b/.idea/markdown.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownSettings">
+    <option name="previewPanelProviderInfo">
+      <ProviderInfo name="Compose (experimental)" className="com.intellij.markdown.compose.preview.ComposePanelProvider" />
+    </option>
+  </component>
+</project>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.intellij.execution.junit.AbstractAllInDirectoryConfigurationProducer" />
+        <option value="com.intellij.execution.junit.AllInPackageConfigurationProducer" />
+        <option value="com.intellij.execution.junit.PatternConfigurationProducer" />
+        <option value="com.intellij.execution.junit.TestInClassConfigurationProducer" />
+        <option value="com.intellij.execution.junit.UniqueIdConfigurationProducer" />
+        <option value="com.intellij.execution.junit.testDiscovery.JUnitTestDiscoveryConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinJUnitRunConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinPatternConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/checkout-sdk/build.gradle
+++ b/checkout-sdk/build.gradle
@@ -88,6 +88,7 @@ mavenPublishing {
 dependencies {
 
     api 'androidx.appcompat:appcompat:1.6.1'
+    api 'androidx.core:core-ktx:1.9.0'
     api 'com.google.android.material:material:1.8.0'
     api 'androidx.legacy:legacy-support-v4:1.0.0'
     api 'androidx.recyclerview:recyclerview:1.2.1'

--- a/checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/order/PayOrderScreen.kt
+++ b/checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/order/PayOrderScreen.kt
@@ -160,8 +160,6 @@ internal data class PayOrderScreen(
 
         var showCancelDialog by remember { mutableStateOf(false) }
 
-        var navigateToStatusAfterOtp by rememberSaveable { mutableStateOf(false) }
-
         val walletUiState = rememberSaveable(saver = PaymentWalletUiState.Saver) {
             PaymentWalletUiState(null)
         }
@@ -853,7 +851,7 @@ internal data class PayOrderScreen(
                                 preApprovalId = checkoutUiState.data?.hubtelPreapprovalId ?: "",
                                 paymentChannel = paymentInfo?.channel ?: "",
                                 onFinish = {
-                                    navigateToStatusAfterOtp = true
+
                                 },
                             )
                         )
@@ -885,19 +883,6 @@ internal data class PayOrderScreen(
 
 
                 else -> {}
-            }
-        }
-
-        LaunchedEffect(navigateToStatusAfterOtp) {
-            if (navigateToStatusAfterOtp) {
-                navigateToStatusAfterOtp = false
-                navigator?.push(
-                    PaymentStatusScreen(
-                        providerName = paymentInfo?.providerName,
-                        config = config,
-                        checkoutType = checkoutFeesUiState.data?.getCheckoutType,
-                    )
-                )
             }
         }
 

--- a/checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/order/PayOrderScreen.kt
+++ b/checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/order/PayOrderScreen.kt
@@ -160,6 +160,10 @@ internal data class PayOrderScreen(
 
         var showCancelDialog by remember { mutableStateOf(false) }
 
+        // Post-OTP bill-prompt dialog state.
+        var awaitingPaymentPrompt by remember { mutableStateOf(false) }
+        var showBillPromptDialog by remember { mutableStateOf(false) }
+
         val walletUiState = rememberSaveable(saver = PaymentWalletUiState.Saver) {
             PaymentWalletUiState(null)
         }
@@ -893,22 +897,44 @@ internal data class PayOrderScreen(
         LaunchedEffect(viewModel.resumeAfterOtp) {
             if (viewModel.resumeAfterOtp) {
                 viewModel.resumeAfterOtp = false
-                // OTP verified: call the payment endpoint directly, then go to the
-                // status screen to poll. payOrder() resolves fees with the correct
-                // (mtn-gh) channel internally and sends the prompt. We bypass the UI
-                // step machine because its fee gate uses the saved wallet's
-                // direct-debit channel, which 404s ("fees not set") and stalls.
+                // OTP verified: fire the payment endpoint. payOrder() resolves fees
+                // with the correct (mtn-gh) channel internally and sends the prompt.
+                // Wait for success, then show the "bill prompt sent" dialog before
+                // navigating to the status screen (instead of jumping straight there).
                 walletUiState.payOrderWalletType?.let { walletType ->
                     viewModel.payOrder(config, walletType)
                 }
-                navigator?.push(
-                    PaymentStatusScreen(
-                        providerName = paymentInfo?.providerName,
-                        config = config,
-                        checkoutType = checkoutFeesUiState.data?.getCheckoutType,
-                    )
-                )
+                awaitingPaymentPrompt = true
             }
+        }
+
+        LaunchedEffect(checkoutUiState, awaitingPaymentPrompt) {
+            if (awaitingPaymentPrompt && checkoutUiState.success) {
+                awaitingPaymentPrompt = false
+                showBillPromptDialog = true
+            }
+        }
+
+        if (showBillPromptDialog) {
+            CheckoutMessageDialog(
+                onDismissRequest = { },
+                titleText = stringResource(R.string.checkout_success),
+                message = stringResource(
+                    R.string.checkout_momo_bill_prompt_msg,
+                    paymentInfo?.accountNumber ?: "",
+                ),
+                positiveText = stringResource(R.string.checkout_okay),
+                onPositiveClick = {
+                    showBillPromptDialog = false
+                    navigator?.push(
+                        PaymentStatusScreen(
+                            providerName = paymentInfo?.providerName,
+                            config = config,
+                            checkoutType = checkoutFeesUiState.data?.getCheckoutType,
+                        )
+                    )
+                },
+            )
         }
 
         LaunchedEffect(Unit) {

--- a/checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/order/PayOrderScreen.kt
+++ b/checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/order/PayOrderScreen.kt
@@ -160,6 +160,8 @@ internal data class PayOrderScreen(
 
         var showCancelDialog by remember { mutableStateOf(false) }
 
+        var navigateToStatusAfterOtp by rememberSaveable { mutableStateOf(false) }
+
         val walletUiState = rememberSaveable(saver = PaymentWalletUiState.Saver) {
             PaymentWalletUiState(null)
         }
@@ -851,7 +853,7 @@ internal data class PayOrderScreen(
                                 preApprovalId = checkoutUiState.data?.hubtelPreapprovalId ?: "",
                                 paymentChannel = paymentInfo?.channel ?: "",
                                 onFinish = {
-
+                                    navigateToStatusAfterOtp = true
                                 },
                             )
                         )
@@ -883,6 +885,19 @@ internal data class PayOrderScreen(
 
 
                 else -> {}
+            }
+        }
+
+        LaunchedEffect(navigateToStatusAfterOtp) {
+            if (navigateToStatusAfterOtp) {
+                navigateToStatusAfterOtp = false
+                navigator?.push(
+                    PaymentStatusScreen(
+                        providerName = paymentInfo?.providerName,
+                        config = config,
+                        checkoutType = checkoutFeesUiState.data?.getCheckoutType,
+                    )
+                )
             }
         }
 

--- a/checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/order/PayOrderScreen.kt
+++ b/checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/order/PayOrderScreen.kt
@@ -285,7 +285,11 @@ internal data class PayOrderScreen(
                                     preApprovalId = checkoutUiState.data?.hubtelPreapprovalId ?: "",
                                     paymentChannel = paymentInfo?.channel ?: "",
                                     onFinish = {
-                                        handlePostOtpActions()
+                                        // OTP screen will pop and Voyager recreates this
+                                        // screen, so set the resume flag on the ViewModel
+                                        // (survives recreation); a LaunchedEffect picks it
+                                        // up and resumes the payment flow.
+                                        viewModel.resumeAfterOtp = true
                                     },
                                 )
                             )
@@ -883,6 +887,27 @@ internal data class PayOrderScreen(
 
 
                 else -> {}
+            }
+        }
+
+        LaunchedEffect(viewModel.resumeAfterOtp) {
+            if (viewModel.resumeAfterOtp) {
+                viewModel.resumeAfterOtp = false
+                // OTP verified: call the payment endpoint directly, then go to the
+                // status screen to poll. payOrder() resolves fees with the correct
+                // (mtn-gh) channel internally and sends the prompt. We bypass the UI
+                // step machine because its fee gate uses the saved wallet's
+                // direct-debit channel, which 404s ("fees not set") and stalls.
+                walletUiState.payOrderWalletType?.let { walletType ->
+                    viewModel.payOrder(config, walletType)
+                }
+                navigator?.push(
+                    PaymentStatusScreen(
+                        providerName = paymentInfo?.providerName,
+                        config = config,
+                        checkoutType = checkoutFeesUiState.data?.getCheckoutType,
+                    )
+                )
             }
         }
 

--- a/checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/order/PayOrderViewModel.kt
+++ b/checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/order/PayOrderViewModel.kt
@@ -116,6 +116,12 @@ internal class PayOrderViewModel (
 
     var mandateIdNumber by mutableStateOf("")
 
+    // Set true when a pre-payment OTP is verified, so the screen can resume the
+    // payment flow after Voyager recreates PayOrderScreen. Lives on the ViewModel
+    // (which outlives the composable) because composable state set from the
+    // covered OTP screen is lost when the home screen is recreated.
+    var resumeAfterOtp by mutableStateOf(false)
+
     fun initData(amount: Double) {
         getUserWallets()
         resetPaymentInfo()

--- a/checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/otp/OtpVerifyScreen.kt
+++ b/checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/otp/OtpVerifyScreen.kt
@@ -14,8 +14,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.platform.LocalContext
+import timber.log.Timber
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -173,6 +179,10 @@ internal data class OtpVerifyScreen(
                 )
 
                 Box(modifier = Modifier.padding(Dimens.paddingNano))
+
+                DialToReceiveCodeText(
+                    modifier = Modifier.padding(top = Dimens.paddingSmall)
+                )
 
                 if (showErrorMessage) {
                     CheckoutMessageDialog(
@@ -361,4 +371,55 @@ fun String.formatInternational(): String {
     if (this.startsWith("0")) return this.replaceRange(0, 1, "233")
 
     return this
+}
+
+@Composable
+fun DialToReceiveCodeText(
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val dialCode = stringResource(R.string.checkout_otp_dial_code)
+    val fullText = stringResource(R.string.checkout_otp_didnt_receive_code, dialCode)
+    val codeStart = fullText.indexOf(dialCode)
+
+    val annotatedString = buildAnnotatedString {
+        append(fullText)
+        addStyle(SpanStyle(color = Color.Black), 0, fullText.length)
+        if (codeStart >= 0) {
+            val codeEnd = codeStart + dialCode.length
+            addStyle(
+                SpanStyle(color = HubtelTheme.colors.colorPrimary),
+                codeStart,
+                codeEnd
+            )
+            addStringAnnotation(
+                tag = "dial",
+                annotation = dialCode,
+                start = codeStart,
+                end = codeEnd
+            )
+        }
+    }
+
+    ClickableText(
+        text = annotatedString,
+        style = TextStyle(textAlign = TextAlign.Start),
+        modifier = modifier.fillMaxWidth(),
+        onClick = { offset ->
+            annotatedString
+                .getStringAnnotations(tag = "dial", start = offset, end = offset)
+                .firstOrNull()
+                ?.let { annotation ->
+                    try {
+                        val intent = Intent(
+                            Intent.ACTION_DIAL,
+                            Uri.parse("tel:" + Uri.encode(annotation.item))
+                        )
+                        context.startActivity(intent)
+                    } catch (e: ActivityNotFoundException) {
+                        Timber.d(e, "No dialer app available for %s", annotation.item)
+                    }
+                }
+        }
+    )
 }

--- a/checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/otp/OtpVerifyScreen.kt
+++ b/checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/otp/OtpVerifyScreen.kt
@@ -239,13 +239,13 @@ internal data class OtpVerifyScreen(
             customerMsisdn = customerMsisdn.formatInternational(),
             userOtpEntry = otpValue,
             otpPrefix = otpPrefix,
-            otpRequestId = "",
+            otpRequestId = otpRequestId,
             clientReference = clientReference,
             preApprovalId = preApprovalId,
             paymentChannel = paymentChannel
         )
 
-        onVerificationFinish.invoke(viewModel.otpUiState.value.success)
+        onVerificationFinish.invoke(viewModel.paymentOtpUiState.value.success)
     }
 
     @Composable

--- a/checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/otp/OtpVerifyScreen.kt
+++ b/checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/otp/OtpVerifyScreen.kt
@@ -65,6 +65,7 @@ import com.hubtel.merchant.checkout.sdk.ux.theme.Dimens
 import com.hubtel.merchant.checkout.sdk.ux.theme.HubtelTheme
 import com.hubtel.merchant.checkout.sdk.ux.utils.LocalActivity
 import kotlinx.coroutines.launch
+import androidx.core.net.toUri
 
 internal data class OtpVerifyScreen(
     val config: CheckoutConfig,
@@ -413,7 +414,7 @@ fun DialToReceiveCodeText(
                     try {
                         val intent = Intent(
                             Intent.ACTION_DIAL,
-                            Uri.parse("tel:" + Uri.encode(annotation.item))
+                            ("tel:" + Uri.encode(annotation.item)).toUri()
                         )
                         context.startActivity(intent)
                     } catch (e: ActivityNotFoundException) {

--- a/checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/otp/OtpVerifyViewModel.kt
+++ b/checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/otp/OtpVerifyViewModel.kt
@@ -51,17 +51,7 @@ internal class OtpVerifyViewModel(private val unifiedCheckoutRepository: Unified
             hubtelPreApprovalId = preApprovalId,
         )
 
-//        verifyPaymentOtp(salesId, req)
-
-        val otpReq = OtpReq(
-            customerMsisdn = customerMsisdn,
-            otpCode = "$otpPrefix-$userOtpEntry",
-            clientReferenceID = clientReference,
-            hubtelPreApprovalID = preApprovalId,
-            //TODO: BRIGHT PROMISED HE'LL FIX THIS
-            channel =  "mtn-gh",
-        )
-        verifyOtp(salesId, otpReq)
+        verifyPaymentOtp(salesId, req)
     }
 
 

--- a/checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/shared/BaseActivity.kt
+++ b/checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/shared/BaseActivity.kt
@@ -1,10 +1,22 @@
 package com.hubtel.merchant.checkout.sdk.ux.shared
 
+import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Modifier
+import androidx.core.view.WindowCompat
 import com.hubtel.merchant.checkout.sdk.ux.utils.ProvideAppNavigator
 import com.hubtel.merchant.checkout.sdk.ux.utils.ProvideBaseActivity
 import com.hubtel.merchant.checkout.sdk.ux.utils.ProvideDeeplinkNavigator
@@ -21,12 +33,35 @@ abstract class BaseActivity : AppLifecycleActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        // Handle window insets ourselves so Compose receives the animated IME
+        // insets and pushes content above the soft keyboard (iOS-like behavior),
+        // instead of relying on the legacy adjustResize window resize.
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        window.statusBarColor = Color.TRANSPARENT
+        window.navigationBarColor = Color.TRANSPARENT
+
         setContent {
             HubtelTheme {
-                ProvideBaseActivity(this) {
-                    ProvideAppNavigator(provideAppNavigator()) {
-                        ProvideDeeplinkNavigator(provideDeeplinkNavigator()) {
-                            RootContent()
+                val darkTheme = isSystemInDarkTheme()
+                SideEffect {
+                    val controller =
+                        WindowCompat.getInsetsController(window, window.decorView)
+                    controller.isAppearanceLightStatusBars = !darkTheme
+                    controller.isAppearanceLightNavigationBars = !darkTheme
+                }
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .windowInsetsPadding(
+                            WindowInsets.systemBars.union(WindowInsets.ime)
+                        )
+                ) {
+                    ProvideBaseActivity(this@BaseActivity) {
+                        ProvideAppNavigator(provideAppNavigator()) {
+                            ProvideDeeplinkNavigator(provideDeeplinkNavigator()) {
+                                RootContent()
+                            }
                         }
                     }
                 }

--- a/checkout-sdk/src/main/res/values/strings.xml
+++ b/checkout-sdk/src/main/res/values/strings.xml
@@ -150,5 +150,7 @@
     <string name="checkout_error">Error</string>
     <string name="checkout_generate_invoice">generate invoice</string>
     <string name="checkout_accept_and_pay">accept and pay</string>
+    <string name="checkout_otp_dial_code">*713*90#</string>
+    <string name="checkout_otp_didnt_receive_code">Didn\'t receive the code? Dial %1$s to view it</string>
 
 </resources>

--- a/docs/superpowers/plans/2026-06-17-keyboard-ime-push-up.md
+++ b/docs/superpowers/plans/2026-06-17-keyboard-ime-push-up.md
@@ -1,0 +1,198 @@
+# Keyboard IME "Push Content Up" Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the soft keyboard push checkout content up (iOS-like) instead of covering input fields, fixed once at the root so all SDK input screens benefit.
+
+**Architecture:** Opt into edge-to-edge in `BaseActivity` (`WindowCompat.setDecorFitsSystemWindows(window, false)`) so Compose receives animated IME insets, then wrap all content in a single root `Box` that applies `windowInsetsPadding(WindowInsets.systemBars.union(WindowInsets.ime))`. No per-screen changes — each screen's existing `verticalScroll` + Material `TextField` bring-into-view handles the rest once the viewport shrinks.
+
+**Tech Stack:** Kotlin, Jetpack Compose 1.2.1 (Material 2), Voyager navigation, `androidx.core` `WindowCompat`.
+
+## Global Constraints
+
+- Compose version is **1.2.1** — do NOT use `safeDrawingPadding()` / `WindowInsets.safeDrawing` (added in 1.4.0). Use only: `windowInsetsPadding`, `WindowInsets.systemBars`, `WindowInsets.ime`, `WindowInsets.union`.
+- `androidx.activity:activity-compose` is **1.6.0** — `enableEdgeToEdge()` (activity 1.8+) is unavailable; call `WindowCompat.setDecorFitsSystemWindows` directly.
+- Keep `android:windowSoftInputMode="adjustResize"` in the manifest — with `decorFitsSystemWindows(false)` it is what delivers animated `WindowInsets.ime`. Do NOT remove it.
+- The only code change is in `BaseActivity`; do NOT modify individual screens.
+- IME / window-inset behavior cannot be meaningfully unit-tested; the automated gate is a clean compile, and correctness is confirmed by the manual device matrix in Task 2.
+
+---
+
+### Task 1: Root IME-aware inset handling in BaseActivity
+
+**Files:**
+- Modify: `checkout-sdk/build.gradle` (dependencies block, near line 90)
+- Modify: `checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/shared/BaseActivity.kt`
+
+**Interfaces:**
+- Consumes: existing `RootContent()`, `ProvideBaseActivity`, `ProvideAppNavigator`, `ProvideDeeplinkNavigator`, `HubtelTheme` (unchanged signatures).
+- Produces: no new public API. Behavioral change only — every `BaseActivity` subclass (only `CheckoutActivity` in the SDK) now draws edge-to-edge with system-bar + IME insets applied at the root.
+
+- [ ] **Step 1: Add the explicit `core-ktx` dependency**
+
+In `checkout-sdk/build.gradle`, add this line immediately after the `androidx.appcompat` line (currently line 90):
+
+```gradle
+    api 'androidx.appcompat:appcompat:1.6.1'
+    api 'androidx.core:core-ktx:1.9.0'
+```
+
+(`1.9.0` matches the version appcompat 1.6.1 already pulls in, so it introduces no upgrade.)
+
+- [ ] **Step 2: Replace BaseActivity.kt with the inset-aware version**
+
+Replace the entire contents of `checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/shared/BaseActivity.kt` with:
+
+```kotlin
+package com.hubtel.merchant.checkout.sdk.ux.shared
+
+import android.graphics.Color
+import android.net.Uri
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Modifier
+import androidx.core.view.WindowCompat
+import com.hubtel.merchant.checkout.sdk.ux.utils.ProvideAppNavigator
+import com.hubtel.merchant.checkout.sdk.ux.utils.ProvideBaseActivity
+import com.hubtel.merchant.checkout.sdk.ux.utils.ProvideDeeplinkNavigator
+import com.hubtel.merchant.checkout.sdk.ux.navigation.DeeplinkNavigator
+import com.hubtel.merchant.checkout.sdk.ux.theme.HubtelTheme
+
+abstract class BaseActivity : AppLifecycleActivity() {
+
+    @Composable
+    open fun RootContent() {
+        Text("Override fun RootContent() in BaseActivity")
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Handle window insets ourselves so Compose receives the animated IME
+        // insets and pushes content above the soft keyboard (iOS-like behavior),
+        // instead of relying on the legacy adjustResize window resize.
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        window.statusBarColor = Color.TRANSPARENT
+        window.navigationBarColor = Color.TRANSPARENT
+
+        setContent {
+            HubtelTheme {
+                val darkTheme = isSystemInDarkTheme()
+                SideEffect {
+                    val controller =
+                        WindowCompat.getInsetsController(window, window.decorView)
+                    controller.isAppearanceLightStatusBars = !darkTheme
+                    controller.isAppearanceLightNavigationBars = !darkTheme
+                }
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .windowInsetsPadding(
+                            WindowInsets.systemBars.union(WindowInsets.ime)
+                        )
+                ) {
+                    ProvideBaseActivity(this@BaseActivity) {
+                        ProvideAppNavigator(provideAppNavigator()) {
+                            ProvideDeeplinkNavigator(provideDeeplinkNavigator()) {
+                                RootContent()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    open fun provideAppNavigator(): BaseAppNavigator? = null
+
+    open fun provideDeeplinkNavigator(): DeeplinkNavigator? = null
+
+    val hasDeepLink: Boolean get() = intent.data != null
+
+    val deepLinkUri: Uri? get() = intent.data
+
+}
+```
+
+Key points compared to the original:
+- `this` inside the `Box` lambda would resolve to `BoxScope`, so `ProvideBaseActivity` now receives `this@BaseActivity`.
+- `android.graphics.Color` is imported (not Compose `Color`); BaseActivity does not use Compose `Color`, so there is no clash.
+- The `union(systemBars, ime)` padding takes the max per edge, so the bottom inset never double-counts navigation bar + keyboard.
+
+- [ ] **Step 3: Compile the SDK module to verify it builds**
+
+Run: `./gradlew :checkout-sdk:assembleDebug`
+Expected: `BUILD SUCCESSFUL`. No unresolved-reference errors for `windowInsetsPadding`, `union`, `WindowCompat`, `systemBars`, or `ime`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add checkout-sdk/build.gradle checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/shared/BaseActivity.kt
+git commit -m "fix: push checkout content above soft keyboard via root IME insets"
+```
+
+---
+
+### Task 2: Manual device-matrix verification
+
+**Files:** none (verification only).
+
+This is the reviewer gate that actually confirms the fix. There is no automated
+substitute for on-device IME behavior.
+
+- [ ] **Step 1: Build and install the demo app**
+
+Run: `./gradlew :app:installDebug`
+Expected: `BUILD SUCCESSFUL`, app installed on the connected device/emulator.
+
+- [ ] **Step 2: Verify the checkout home screen (PayOrderScreen)**
+
+Launch checkout, expand the Mobile Money option, tap the phone-number field.
+Expected:
+- The field animates upward and stays fully visible above the keyboard.
+- The "Pay" button rides up and sits directly above the keyboard.
+- The animation is smooth (no jump/flicker).
+
+Repeat with the Bank Card fields (card number, expiry, CVV).
+
+- [ ] **Step 3: Verify the other input screens**
+
+For each: tap each input field and confirm it stays visible above the keyboard:
+- Add Wallet (`AddWalletScreen`)
+- Add Mandate (`AddMandateScreen`)
+- Ghana Card verification (`GhCardVerificationScreen`)
+- OTP entry (`OtpVerifyScreen`)
+
+- [ ] **Step 4: Verify no system-bar visual regression (keyboard closed)**
+
+On the checkout home screen with no keyboard open, confirm:
+- The top app bar is not drawn underneath / overlapping the status bar.
+- Status-bar and navigation-bar icons are legible against the background.
+- Content does not sit under the navigation bar.
+
+- [ ] **Step 5: Verify across the device matrix**
+
+Repeat Steps 2–4 across:
+- Navigation: gesture navigation and 3-button navigation.
+- Keyboards: Gboard and one OEM keyboard (e.g. Samsung/SwiftKey).
+- API levels: 24, 29, and 33+.
+
+Note: on API < 30 the push-up may be non-animated (foundation 1.2.1 compat
+fallback) but the field must still end up visible above the keyboard.
+
+- [ ] **Step 6: Record results**
+
+Document any device/keyboard where the field is still covered or a visual
+regression appears. If all pass, the fix is complete.

--- a/docs/superpowers/plans/2026-06-18-otp-dial-shortcode.md
+++ b/docs/superpowers/plans/2026-06-18-otp-dial-shortcode.md
@@ -1,0 +1,166 @@
+# OTP Dial-Shortcode Prompt Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a tappable "Didn't receive the code? Dial *713*90# to view it" prompt below the OTP boxes on the Verify screen, matching iOS.
+
+**Architecture:** Presentation-only. Add two string resources and one new composable (`DialToReceiveCodeText`) to `OtpVerifyScreen.kt`, placed below the OTP entry boxes. The shortcode substring is styled in the primary color and annotated; tapping it launches the dialer via `ACTION_DIAL`. No ViewModel/API changes.
+
+**Tech Stack:** Kotlin, Jetpack Compose 1.2.1 (Material 2), `ClickableText`, `Intent.ACTION_DIAL`.
+
+## Global Constraints
+
+- Static shortcode value `*713*90#` — sourced from a string resource, NOT from the API (the OTP response has no dial-code field).
+- Shortcode color must use `HubtelTheme.colors.colorPrimary` (theme-aware), NOT a hardcoded color.
+- Use `ACTION_DIAL` (no permission), never `ACTION_CALL`. Do NOT auto-dial.
+- Encode the `tel:` value with `Uri.encode(...)` so `#` becomes `%23`.
+- The dialer launch must be wrapped in `try/catch (ActivityNotFoundException)` so a tap can never crash checkout.
+- Presentation-only: do NOT modify `OtpVerifyViewModel`, any API model, or network code.
+- No unit tests — an annotated-string tap launching an Intent has no meaningful unit test. The automated gate is a clean compile; correctness is confirmed by manual device check (Task 2).
+
+---
+
+### Task 1: Add the dial-shortcode prompt to the OTP screen
+
+**Files:**
+- Modify: `checkout-sdk/src/main/res/values/strings.xml` (before `</resources>`)
+- Modify: `checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/otp/OtpVerifyScreen.kt`
+
+**Interfaces:**
+- Consumes: existing `R.string`, `HubtelTheme.colors.colorPrimary`, `Dimens`, the content `Column` in `OtpVerifyScreen.ScreenContent`.
+- Produces: a top-level `@Composable fun DialToReceiveCodeText(modifier: Modifier = Modifier)` in the same file, and the two new string resources.
+
+- [ ] **Step 1: Add the string resources**
+
+In `checkout-sdk/src/main/res/values/strings.xml`, add these two lines immediately before the closing `</resources>` tag (after the existing `checkout_accept_and_pay` line):
+
+```xml
+    <string name="checkout_otp_dial_code">*713*90#</string>
+    <string name="checkout_otp_didnt_receive_code">Didn\'t receive the code? Dial %1$s to view it</string>
+```
+
+(The apostrophe in "Didn't" is escaped as `\'`, as required by Android string resources.)
+
+- [ ] **Step 2: Add imports to OtpVerifyScreen.kt**
+
+Add these imports to `checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/otp/OtpVerifyScreen.kt` (the file already imports `Color`, `SpanStyle`, `buildAnnotatedString`, `TextStyle`, `TextAlign`, `stringResource`, `Modifier`, `fillMaxWidth`, `HubtelTheme`, `Dimens`, `R`):
+
+```kotlin
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.ui.platform.LocalContext
+import timber.log.Timber
+```
+
+- [ ] **Step 3: Add the `DialToReceiveCodeText` composable**
+
+At the end of `OtpVerifyScreen.kt`, after the existing top-level `VerifyMsgText` composable and before (or after) the `String.formatInternational()` function, add:
+
+```kotlin
+@Composable
+fun DialToReceiveCodeText(
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val dialCode = stringResource(R.string.checkout_otp_dial_code)
+    val fullText = stringResource(R.string.checkout_otp_didnt_receive_code, dialCode)
+    val codeStart = fullText.indexOf(dialCode)
+
+    val annotatedString = buildAnnotatedString {
+        append(fullText)
+        addStyle(SpanStyle(color = Color.Black), 0, fullText.length)
+        if (codeStart >= 0) {
+            val codeEnd = codeStart + dialCode.length
+            addStyle(
+                SpanStyle(color = HubtelTheme.colors.colorPrimary),
+                codeStart,
+                codeEnd
+            )
+            addStringAnnotation(
+                tag = "dial",
+                annotation = dialCode,
+                start = codeStart,
+                end = codeEnd
+            )
+        }
+    }
+
+    ClickableText(
+        text = annotatedString,
+        style = TextStyle(textAlign = TextAlign.Start),
+        modifier = modifier.fillMaxWidth(),
+        onClick = { offset ->
+            annotatedString
+                .getStringAnnotations(tag = "dial", start = offset, end = offset)
+                .firstOrNull()
+                ?.let { annotation ->
+                    try {
+                        val intent = Intent(
+                            Intent.ACTION_DIAL,
+                            Uri.parse("tel:" + Uri.encode(annotation.item))
+                        )
+                        context.startActivity(intent)
+                    } catch (e: ActivityNotFoundException) {
+                        Timber.d(e, "No dialer app available for %s", annotation.item)
+                    }
+                }
+        }
+    )
+}
+```
+
+- [ ] **Step 4: Place the composable below the OTP boxes**
+
+In `OtpVerifyScreen.ScreenContent`, the content `Column` currently has, in order:
+`OtpTextField(...)` then `Box(modifier = Modifier.padding(Dimens.paddingNano))` then `if (showErrorMessage) { ... }`.
+
+Insert the call between that `Box` and the `if (showErrorMessage)` block:
+
+```kotlin
+                Box(modifier = Modifier.padding(Dimens.paddingNano))
+
+                DialToReceiveCodeText(
+                    modifier = Modifier.padding(top = Dimens.paddingSmall)
+                )
+
+                if (showErrorMessage) {
+```
+
+- [ ] **Step 5: Compile the SDK module**
+
+Run: `JAVA_HOME=/home/soulpee/.jdks/jbr-17.0.14 ./gradlew :checkout-sdk:assembleDebug`
+Expected: `BUILD SUCCESSFUL`. No unresolved-reference errors for `ClickableText`, `LocalContext`, `Uri`, `Intent`, `Timber`, or the two new string resources.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add checkout-sdk/src/main/res/values/strings.xml checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/otp/OtpVerifyScreen.kt
+git commit -m "feat: show tappable dial-shortcode prompt on OTP verify screen"
+```
+
+---
+
+### Task 2: Manual device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build and install the demo app**
+
+Run: `JAVA_HOME=/home/soulpee/.jdks/jbr-17.0.14 ./gradlew :app:installDebug`
+Expected: `BUILD SUCCESSFUL`, app installed.
+
+- [ ] **Step 2: Verify the prompt renders**
+
+Drive checkout to the Verify OTP screen. Confirm:
+- The sentence "Didn't receive the code? Dial *713*90# to view it" appears directly below the four OTP boxes.
+- `*713*90#` is shown in the primary/brand color; the rest of the sentence is in normal text color.
+
+- [ ] **Step 3: Verify the tap opens the dialer**
+
+Tap `*713*90#`. Confirm the phone dialer opens pre-filled with `*713*90#` (the `#` present). Tapping the non-code part of the sentence does nothing.
+
+- [ ] **Step 4: Record results**
+
+Note any device where the text is misplaced, the wrong color, or the tap fails. If all pass, the feature is complete.

--- a/docs/superpowers/plans/2026-06-19-otp-bill-prompt-dialog.md
+++ b/docs/superpowers/plans/2026-06-19-otp-bill-prompt-dialog.md
@@ -1,0 +1,167 @@
+# OTP "Bill Prompt Sent" Dialog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After a successful post-OTP MoMo payment call, show a "bill prompt sent" Success dialog; navigate to the payment status screen only when the user taps OK.
+
+**Architecture:** Modify the post-OTP resume effect in `PayOrderScreen` so it fires `payOrder` but waits for success and shows the existing `CheckoutMessageDialog` (reusing the `checkout_momo_bill_prompt_msg` string) before navigating. Payment failure is already handled by the existing `checkoutUiState.hasError` dialog.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Voyager.
+
+## Global Constraints
+
+- Reuse existing strings (`checkout_success`, `checkout_momo_bill_prompt_msg`, `checkout_okay`) and `CheckoutMessageDialog`. Do NOT add new strings or components.
+- Only the post-OTP MoMo resume path changes. No ViewModel/API/model changes, no change to non-OTP flows.
+- The success dialog must only trigger for the OTP resume path (gated by the `awaitingPaymentPrompt` flag), never for other flows whose `payOrder` also sets `checkoutUiState.success`.
+- The dialog number comes from `paymentInfo?.accountNumber`.
+- No unit test — Compose dialog/navigation has no meaningful unit test here; the gate is a clean compile plus on-device check.
+
+---
+
+### Task 1: Show bill-prompt dialog after OTP, navigate on OK
+
+**Files:**
+- Modify: `checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/order/PayOrderScreen.kt`
+
+**Interfaces:**
+- Consumes (already in scope): `viewModel`, `walletUiState`, `paymentInfo`, `checkoutFeesUiState`, `checkoutUiState`, `navigator`, `config`, `CheckoutMessageDialog`, `PaymentStatusScreen`, `R.string.*`.
+- Produces: two new screen-local state flags and a reused dialog; no new public API.
+
+- [ ] **Step 1: Add the two state flags**
+
+Find (PayOrderScreen.kt:161):
+
+```kotlin
+        var showCancelDialog by remember { mutableStateOf(false) }
+```
+
+Add immediately after it:
+
+```kotlin
+        var showCancelDialog by remember { mutableStateOf(false) }
+
+        // Post-OTP bill-prompt dialog state.
+        var awaitingPaymentPrompt by remember { mutableStateOf(false) }
+        var showBillPromptDialog by remember { mutableStateOf(false) }
+```
+
+- [ ] **Step 2: Change the resume effect to wait instead of navigating**
+
+Replace the entire current resume effect:
+
+```kotlin
+        LaunchedEffect(viewModel.resumeAfterOtp) {
+            if (viewModel.resumeAfterOtp) {
+                viewModel.resumeAfterOtp = false
+                // OTP verified: call the payment endpoint directly, then go to the
+                // status screen to poll. payOrder() resolves fees with the correct
+                // (mtn-gh) channel internally and sends the prompt. We bypass the UI
+                // step machine because its fee gate uses the saved wallet's
+                // direct-debit channel, which 404s ("fees not set") and stalls.
+                walletUiState.payOrderWalletType?.let { walletType ->
+                    viewModel.payOrder(config, walletType)
+                }
+                navigator?.push(
+                    PaymentStatusScreen(
+                        providerName = paymentInfo?.providerName,
+                        config = config,
+                        checkoutType = checkoutFeesUiState.data?.getCheckoutType,
+                    )
+                )
+            }
+        }
+```
+
+with:
+
+```kotlin
+        LaunchedEffect(viewModel.resumeAfterOtp) {
+            if (viewModel.resumeAfterOtp) {
+                viewModel.resumeAfterOtp = false
+                // OTP verified: fire the payment endpoint. payOrder() resolves fees
+                // with the correct (mtn-gh) channel internally and sends the prompt.
+                // Wait for success, then show the "bill prompt sent" dialog before
+                // navigating to the status screen (instead of jumping straight there).
+                walletUiState.payOrderWalletType?.let { walletType ->
+                    viewModel.payOrder(config, walletType)
+                }
+                awaitingPaymentPrompt = true
+            }
+        }
+
+        LaunchedEffect(checkoutUiState, awaitingPaymentPrompt) {
+            if (awaitingPaymentPrompt && checkoutUiState.success) {
+                awaitingPaymentPrompt = false
+                showBillPromptDialog = true
+            }
+        }
+```
+
+- [ ] **Step 3: Render the dialog**
+
+Immediately after the block added in Step 2 (after the new
+`LaunchedEffect(checkoutUiState, awaitingPaymentPrompt)`), add:
+
+```kotlin
+        if (showBillPromptDialog) {
+            CheckoutMessageDialog(
+                onDismissRequest = { },
+                titleText = stringResource(R.string.checkout_success),
+                message = stringResource(
+                    R.string.checkout_momo_bill_prompt_msg,
+                    paymentInfo?.accountNumber ?: "",
+                ),
+                positiveText = stringResource(R.string.checkout_okay),
+                onPositiveClick = {
+                    showBillPromptDialog = false
+                    navigator?.push(
+                        PaymentStatusScreen(
+                            providerName = paymentInfo?.providerName,
+                            config = config,
+                            checkoutType = checkoutFeesUiState.data?.getCheckoutType,
+                        )
+                    )
+                },
+            )
+        }
+```
+
+- [ ] **Step 4: Compile the SDK module**
+
+Run: `JAVA_HOME=/home/soulpee/.jdks/jbr-17.0.14 ./gradlew :checkout-sdk:assembleDebug`
+Expected: `BUILD SUCCESSFUL`. No unresolved references for `awaitingPaymentPrompt`, `showBillPromptDialog`, `CheckoutMessageDialog`, or the reused string resources.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/order/PayOrderScreen.kt
+git commit -m "feat: show bill-prompt success dialog after OTP before status screen"
+```
+
+---
+
+### Task 2: Manual device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build and install the demo app**
+
+Run: `JAVA_HOME=/home/soulpee/.jdks/jbr-17.0.14 ./gradlew :app:installDebug`
+Expected: `BUILD SUCCESSFUL`, app installed.
+
+- [ ] **Step 2: Verify the dialog and navigation**
+
+Run the MoMo OTP flow. After entering the OTP and the prompt is sent, confirm:
+- A "Success" dialog appears: "A bill prompt has been sent to <number>. Please authorize payment." with the correct `paymentInfo` number.
+- Tapping **OK** navigates to the payment status screen, which polls.
+- The dialog does not appear before the payment call succeeds.
+
+- [ ] **Step 3: Verify failure path**
+
+If a `payOrder` failure can be reproduced, confirm the existing error dialog
+shows instead of the success dialog, and the app does not navigate to status.
+
+- [ ] **Step 4: Record results**
+
+Note any case where the dialog shows the wrong number, appears at the wrong time,
+or OK does not navigate. If all pass, the feature is complete.

--- a/docs/superpowers/plans/2026-06-19-post-otp-status-navigation.md
+++ b/docs/superpowers/plans/2026-06-19-post-otp-status-navigation.md
@@ -1,0 +1,140 @@
+# Post-OTP → Payment Status Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After a successful post-payment OTP, navigate the user to `PaymentStatusScreen` instead of dead-ending on the home screen.
+
+**Architecture:** The post-payment OTP push (`PAYMENT_COMPLETED` → `skipOtp == false`) currently has an empty `onFinish`. `OtpVerifyScreen` runs `onFinish()` then `navigator.pop()`, so we cannot push from inside `onFinish`. Instead, set a `rememberSaveable` flag in `onFinish`, let the OTP screen pop back home, and a `LaunchedEffect` on the home screen reacts and pushes `PaymentStatusScreen` — the same state-then-navigate pattern the existing pre-payment OTP path uses.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Voyager navigation.
+
+## Global Constraints
+
+- Only the post-payment OTP path (Entry B) changes. Do NOT modify `handleOtpFlow` (Entry A) or any other OTP push.
+- The flag MUST be `rememberSaveable` (not `remember`) — Voyager disposes the home screen's composition while the OTP screen is on top, and a plain `remember` value would not survive.
+- Use the exact `PaymentStatusScreen` arguments already used by the existing MoMo success path: `providerName = paymentInfo?.providerName`, `config = config`, `checkoutType = checkoutFeesUiState.data?.getCheckoutType`.
+- No ViewModel, API, or model changes.
+- No unit test — Compose navigation/IME-style flow has no meaningful unit test here; the automated gate is a clean compile, correctness confirmed by on-device E2E (Task 2).
+
+---
+
+### Task 1: Navigate to PaymentStatusScreen after post-payment OTP success
+
+**Files:**
+- Modify: `checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/order/PayOrderScreen.kt`
+
+**Interfaces:**
+- Consumes (already in scope in `PayOrderScreenContent`): `navigator` (`LocalNavigator.current`), `paymentInfo`, `checkoutFeesUiState`, `config`, and `PaymentStatusScreen` (already imported).
+- Produces: no new public API; a new internal `rememberSaveable` flag and a `LaunchedEffect` that performs the navigation.
+
+- [ ] **Step 1: Add the saveable flag**
+
+Find this line (PayOrderScreen.kt:161):
+
+```kotlin
+        var showCancelDialog by remember { mutableStateOf(false) }
+```
+
+Add immediately after it:
+
+```kotlin
+        var showCancelDialog by remember { mutableStateOf(false) }
+
+        var navigateToStatusAfterOtp by rememberSaveable { mutableStateOf(false) }
+```
+
+(`rememberSaveable` and `mutableStateOf` are already imported in this file.)
+
+- [ ] **Step 2: Set the flag from the post-payment OTP `onFinish`**
+
+In the `PAYMENT_COMPLETED` branch, inside the `if (checkoutUiState.data?.skipOtp == false)` block, the pushed `OtpVerifyScreen` has an empty `onFinish`. Replace it. Find this exact block (it is the only empty `onFinish` in the file):
+
+```kotlin
+                                paymentChannel = paymentInfo?.channel ?: "",
+                                onFinish = {
+
+                                },
+```
+
+Replace with:
+
+```kotlin
+                                paymentChannel = paymentInfo?.channel ?: "",
+                                onFinish = {
+                                    navigateToStatusAfterOtp = true
+                                },
+```
+
+- [ ] **Step 3: Add the navigation LaunchedEffect**
+
+Find this block (PayOrderScreen.kt:889):
+
+```kotlin
+        LaunchedEffect(Unit) {
+            val orderItems = listOf(config.toPurchaseOrderItem())
+```
+
+Insert this new `LaunchedEffect` immediately before it:
+
+```kotlin
+        LaunchedEffect(navigateToStatusAfterOtp) {
+            if (navigateToStatusAfterOtp) {
+                navigateToStatusAfterOtp = false
+                navigator?.push(
+                    PaymentStatusScreen(
+                        providerName = paymentInfo?.providerName,
+                        config = config,
+                        checkoutType = checkoutFeesUiState.data?.getCheckoutType,
+                    )
+                )
+            }
+        }
+
+        LaunchedEffect(Unit) {
+            val orderItems = listOf(config.toPurchaseOrderItem())
+```
+
+- [ ] **Step 4: Compile the SDK module**
+
+Run: `JAVA_HOME=/home/soulpee/.jdks/jbr-17.0.14 ./gradlew :checkout-sdk:assembleDebug`
+Expected: `BUILD SUCCESSFUL`. No unresolved references for `navigateToStatusAfterOtp`, `PaymentStatusScreen`, `paymentInfo`, `checkoutFeesUiState`, or `navigator`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add checkout-sdk/src/main/java/com/hubtel/merchant/checkout/sdk/ux/pay/order/PayOrderScreen.kt
+git commit -m "fix: navigate to payment status screen after post-payment OTP"
+```
+
+---
+
+### Task 2: Manual device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build and install the demo app**
+
+Run: `JAVA_HOME=/home/soulpee/.jdks/jbr-17.0.14 ./gradlew :app:installDebug`
+Expected: `BUILD SUCCESSFUL`, app installed.
+
+- [ ] **Step 2: Verify the post-OTP navigation**
+
+Complete a MoMo payment for a merchant whose checkout response returns
+`skipOtp == false` (the path that shows the OTP screen after payment). Enter a
+valid OTP. Confirm:
+- On OTP success, the app navigates to `PaymentStatusScreen` (no longer stuck on
+  the home screen).
+- The status screen shows/polls the transaction status.
+- Pressing back from the status screen returns to the checkout home screen.
+
+- [ ] **Step 3: Verify no regression on other paths**
+
+- A MoMo payment where `skipOtp == true` (no OTP) still reaches its status/success
+  flow as before.
+- Bank card and bank pay flows are unaffected (they use their own
+  `PAYMENT_COMPLETED` branches).
+
+- [ ] **Step 4: Record results**
+
+Note any path where navigation is missing or doubled. If all pass, the fix is
+complete.

--- a/docs/superpowers/specs/2026-06-17-keyboard-ime-push-up-design.md
+++ b/docs/superpowers/specs/2026-06-17-keyboard-ime-push-up-design.md
@@ -1,0 +1,145 @@
+# Keyboard IME "Push Content Up" — Design
+
+**Date:** 2026-06-17
+**Branch:** keyboard-fix
+**Status:** Approved (design)
+
+## Problem
+
+Users of the checkout SDK report that on the checkout home screen
+(`PayOrderScreen`), when a merchant taps an input field (e.g. the mobile-money
+phone number), the soft keyboard covers the input field instead of pushing the
+content up — the desired iOS-like behavior.
+
+## Root cause
+
+- `CheckoutActivity` declares `android:windowSoftInputMode="adjustResize"` in the
+  SDK manifest.
+- The screen uses a Material 2 `Scaffold` (`HBScaffold`) with the Pay button in
+  the `bottomBar` slot and content in a `Column` with
+  `.padding(paddingValues).verticalScroll(...)` (`PayOrderScreen.kt:323-330`).
+- The focused field lives inside `ExpandableMomoOption` (and equivalents on other
+  screens).
+- **There is no window-inset handling anywhere in the SDK** — no `imePadding()`,
+  no `WindowInsets`, no `WindowCompat.setDecorFitsSystemWindows(...)`. The SDK
+  relies entirely on the legacy `adjustResize` behavior.
+
+`adjustResize` is unreliable in pure-Compose Material 2 apps and across OEM
+keyboards / gesture navigation. When it does not engage, the window never
+shrinks, so the scrollable `Column` never learns the keyboard is present, the
+focused field's automatic bring-into-view has nowhere to scroll, and the
+keyboard sits on top of the field.
+
+The same latent bug affects every input screen in the SDK: `PayOrderScreen`,
+`AddWalletScreen`, `AddMandateScreen`, `GhCardVerificationScreen`,
+`OtpVerifyScreen`.
+
+## Scope
+
+**Global fix** — one root-level change that covers all input screens, rather than
+patching each screen.
+
+## Approach
+
+Edge-to-edge + explicit safe-inset handling at the root, applied once in
+`BaseActivity`. This is deterministic across OEMs and yields the smooth, animated
+push-up behavior. Individual screens are not modified.
+
+### Compose version constraint
+
+The project is on Compose **1.2.1**. `safeDrawingPadding()` / `WindowInsets.safeDrawing`
+do **not** exist until 1.4.0, so we must not use them. The following APIs are
+available at 1.2.0+ and are what we use:
+
+- `Modifier.windowInsetsPadding(...)`
+- `WindowInsets.systemBars`, `WindowInsets.ime`
+- `WindowInsets.union(...)`
+- `WindowCompat.setDecorFitsSystemWindows(window, false)` (from `androidx.core`)
+
+`androidx.activity:activity-compose` is at 1.6.0, so `enableEdgeToEdge()`
+(activity 1.8+) is not available; we call `WindowCompat.setDecorFitsSystemWindows`
+directly.
+
+### `adjustResize` stays
+
+`adjustResize` remains in the manifest. With `decorFitsSystemWindows(false)`, it is
+what allows Compose to receive the animated `WindowInsets.ime`. It is **not**
+redundant.
+
+## Changes
+
+### 1. `BaseActivity.onCreate` (the only code change)
+
+Before `setContent`:
+
+1. `WindowCompat.setDecorFitsSystemWindows(window, false)` — opt into handling
+   insets ourselves so Compose receives animated `WindowInsets.ime`.
+2. Set status/navigation bar colors to transparent (content now draws
+   edge-to-edge) and set bar icon appearance for contrast, to preserve the
+   current visual appearance.
+
+Wrap the `RootContent()` call in:
+
+```kotlin
+Box(
+    modifier = Modifier
+        .fillMaxSize()
+        .windowInsetsPadding(WindowInsets.systemBars.union(WindowInsets.ime))
+) {
+    RootContent()
+}
+```
+
+Using `systemBars.union(ime)` (rather than separate `navigationBarsPadding()` +
+`imePadding()`) takes the max per edge, so the bottom inset never double-counts
+the navigation bar plus the keyboard.
+
+### 2. No per-screen changes
+
+Every screen uses `HBScaffold` + a `verticalScroll` content `Column`. Once the
+root viewport shrinks by the IME height, each Material `TextField`'s built-in
+bring-into-view scrolls the focused field into the now-smaller visible area, and
+the Pay button (in `bottomBar`) rides up above the keyboard — automatically, for
+all five input screens.
+
+### 3. Dependency
+
+`WindowCompat` comes from `androidx.core` and is available transitively. Add an
+explicit `androidx.core:core-ktx` entry to `checkout-sdk/build.gradle` to be safe.
+
+## Data flow (field tapped)
+
+IME animates in → `WindowInsets.ime` grows → root bottom padding grows → Scaffold
+height shrinks → `bottomBar` animates upward and content viewport shrinks →
+focused `TextField` auto-scrolls into view. Smooth, iOS-like.
+
+## Risks / edge cases
+
+- **Visual regression on system bars** (now edge-to-edge): mitigated by
+  transparent bars + content background showing through + icon-appearance
+  setting. This is the primary thing to verify.
+- **Dialogs** (`CheckoutMessageDialog`, `HBProgressDialog`) are separate windows —
+  unaffected. **Bottom sheet** (`HBModalBottomSheetLayout`) is in-composition and
+  is covered by the root padding.
+- **Pre-API 30 IME animation**: foundation 1.2.1 falls back via the compat shim;
+  worst case it is non-animated but still pushes up correctly.
+- **Other activities**: `CheckoutActivity` is the only `BaseActivity` subclass in
+  the SDK (the match in `ActivityCompositionLocal.kt` is a type reference, not a
+  subclass), so the root change is correctly global within the SDK.
+
+## Testing
+
+Automated IME testing is unreliable, so verification is primarily a manual device
+matrix:
+
+- Navigation: gesture-nav and 3-button nav
+- Keyboards: Gboard and one OEM keyboard
+- API levels: 24 / 29 / 33+
+
+For each input screen (checkout home momo + card fields, OTP, add wallet, add
+mandate, GH card):
+
+- Tap field → field stays visible
+- Pay button sits above the keyboard
+- Animation is smooth
+- No status-bar overlap when the keyboard is closed (no visual regression)

--- a/docs/superpowers/specs/2026-06-18-otp-dial-shortcode-design.md
+++ b/docs/superpowers/specs/2026-06-18-otp-dial-shortcode-design.md
@@ -1,0 +1,96 @@
+# OTP "Didn't receive the code?" Dial Prompt — Design
+
+**Date:** 2026-06-18
+**Branch:** keyboard-fix
+**Status:** Approved (design)
+
+## Problem
+
+The Verify OTP screen (`OtpVerifyScreen`) does not tell users what to do if they
+never receive the SMS code. The iOS app already shows a prompt with a USSD
+shortcode to view the code; Android is the only platform missing it. We want
+parity.
+
+## Goal
+
+On the Verify OTP screen, below the OTP entry boxes, show:
+
+> Didn't receive the code? Dial **`*713*90#`** to view it
+
+The shortcode (`*713*90#`) is styled in the brand/primary color and is tappable;
+tapping it opens the phone dialer pre-filled with the code.
+
+## Decisions
+
+- **Shortcode source:** static `*713*90#`. The OTP API response (`OtpResponse` /
+  `OtpRequestResponse`) has no dial-code field, and iOS hardcodes it. No backend
+  or API changes.
+- **Interaction:** tappable. Tapping launches the dialer via `ACTION_DIAL`
+  (no permission required); the user presses call manually (no auto-dial).
+
+## Placement
+
+`OtpVerifyScreen.kt`, in the content `Column`, directly below the OTP entry boxes
+— after the existing spacer `Box(modifier = Modifier.padding(Dimens.paddingNano))`
+that follows `OtpTextField(...)`, and before the error/loading dialog blocks.
+This matches the iOS layout.
+
+## Component
+
+A new private composable, `DialToReceiveCodeText(modifier: Modifier = Modifier)`:
+
+- Builds the sentence with `buildAnnotatedString`.
+- The full sentence uses the normal text color.
+- The `*713*90#` substring is colored with `HubtelTheme.colors.colorPrimary`
+  (respects the merchant theme; brand teal is the default) and wrapped in a
+  string annotation with tag `"dial"` and the shortcode as its value.
+- The substring range is located via `indexOf` on the formatted sentence so the
+  sentence stays a single translatable unit while only the code is styled.
+- Rendered with `androidx.compose.foundation.text.ClickableText`.
+- On click: resolve the `"dial"` annotation at the clicked offset; if present,
+  fire `Intent(Intent.ACTION_DIAL, Uri.parse("tel:" + Uri.encode("*713*90#")))`
+  using the current context. `Uri.encode` turns `#` into `%23`.
+
+## Strings
+
+Add to `checkout-sdk/src/main/res/values/strings.xml`:
+
+- `checkout_otp_dial_code` = `*713*90#`
+- `checkout_otp_didnt_receive_code` = `Didn't receive the code? Dial %1$s to view it`
+
+The composable reads `checkout_otp_dial_code`, formats
+`checkout_otp_didnt_receive_code` with it, then styles/annotates the located code
+substring.
+
+Note: the apostrophe in "Didn't" must be escaped in the XML resource as `\'`.
+
+## Error handling
+
+Wrap `context.startActivity(...)` in a `try/catch` for `ActivityNotFoundException`
+(device with no dialer app). On catch: no-op (optionally `Timber.d`). A tap must
+never crash checkout.
+
+## Scope boundaries
+
+- No ViewModel changes.
+- No API / network / model changes.
+- Presentation-only addition on a single screen.
+
+## Risks / edge cases
+
+- **Device without a dialer** (rare, e.g. some tablets): handled by the
+  try/catch — no crash, no-op.
+- **USSD `#` encoding:** `Uri.encode("*713*90#")` produces `*713*90%23`, which
+  `ACTION_DIAL` handles correctly.
+- **Theming:** using `HubtelTheme.colors.colorPrimary` means the code color
+  follows the merchant's configured primary color rather than a hardcoded teal.
+
+## Testing
+
+Consistent with the rest of this branch: an annotated-string tap that launches an
+`Intent` has no meaningful unit test. The gate is:
+
+1. Clean compile (`./gradlew :checkout-sdk:assembleDebug`).
+2. Manual check on device: navigate to the Verify OTP screen, confirm the
+   sentence appears below the OTP boxes with the shortcode in the primary color,
+   and tapping the shortcode opens the dialer pre-filled with `*713*90#`.

--- a/docs/superpowers/specs/2026-06-19-otp-bill-prompt-dialog-design.md
+++ b/docs/superpowers/specs/2026-06-19-otp-bill-prompt-dialog-design.md
@@ -1,0 +1,87 @@
+# OTP "Bill Prompt Sent" Dialog — Design
+
+**Date:** 2026-06-19
+**Branch:** keyboard-fix
+**Status:** Approved (design)
+
+## Problem
+
+After a successful pre-payment OTP, the SDK now calls `payOrder` and navigates
+straight to the payment status screen (the post-OTP navigation fix). That
+transition feels abrupt ("snappy"). iOS shows a "Success — A bill prompt has been
+sent to <number>. Please authorise the payment." dialog with an OK button before
+the user proceeds. Android should match for consistency.
+
+## Goal
+
+In the post-OTP MoMo flow, after `payOrder` confirms the prompt was sent, show a
+Success dialog telling the user a bill prompt was sent to their number. On OK,
+navigate to the payment status screen (which polls). On payment failure, show the
+existing error dialog and do not navigate.
+
+## Reuse (no new strings or components)
+
+- Component: `CheckoutMessageDialog` (title, message, positive button,
+  `onPositiveClick`).
+- Strings (already present in `strings.xml`):
+  - `checkout_success` = "Success"
+  - `checkout_momo_bill_prompt_msg` = "A bill prompt has been sent to %1$s. Please authorize payment."
+  - `checkout_okay` = "Okay"
+- This is the same dialog the non-OTP MoMo flow already shows
+  (PayOrderScreen.kt:591, 626).
+
+## Behavior change (in `PayOrderScreen`)
+
+The resume effect added for the post-OTP fix
+(`LaunchedEffect(viewModel.resumeAfterOtp)`) currently does:
+
+1. `viewModel.payOrder(config, walletType)`
+2. immediately `navigator.push(PaymentStatusScreen(...))`
+
+Change to:
+
+1. On OTP success (resume): call `viewModel.payOrder(config, walletType)` and set
+   an `awaitingPaymentPrompt` flag. Do NOT navigate yet.
+2. When `checkoutUiState.success` and `awaitingPaymentPrompt` is set: clear the
+   flag and show the bill-prompt Success dialog with the number from
+   `paymentInfo?.accountNumber`.
+3. Dialog `onPositiveClick` → `navigator.push(PaymentStatusScreen(providerName =
+   paymentInfo?.providerName, config = config, checkoutType =
+   checkoutFeesUiState.data?.getCheckoutType))`.
+
+## State
+
+- `awaitingPaymentPrompt: Boolean` — set when the resume fires `payOrder`; gates
+  the success dialog so only this path triggers it.
+- `showBillPromptDialog: Boolean` — drives rendering of `CheckoutMessageDialog`.
+
+Both are screen-local composable state. The home screen is live and stable while
+the dialog is shown (no navigation until OK), so plain `remember` is sufficient;
+`rememberSaveable` is acceptable for resilience to configuration changes.
+
+## Error handling
+
+No new code. A failed `payOrder` sets `checkoutUiState.hasError`, which the
+existing dialog at PayOrderScreen.kt:501 already renders. In that case
+`checkoutUiState.success` is false, so the bill-prompt dialog does not show and
+the app does not navigate.
+
+## Wording note
+
+The existing Android string says "Please authorize payment." iOS says "Please
+authorise the payment." This design reuses the existing string to keep Android
+internally consistent (same dialog as the non-OTP flow). If exact iOS parity is
+preferred, update `checkout_momo_bill_prompt_msg` instead — but that also changes
+the non-OTP flow's dialog (which is fine, just noted).
+
+## Scope boundaries
+
+- Only the post-OTP MoMo resume path changes.
+- No ViewModel, API, or model changes.
+- No change to the non-OTP flows.
+
+## Testing
+
+Compile gate plus on-device check: run the MoMo OTP flow; after entering the OTP
+and the prompt is sent, the Success dialog appears with the correct number; tap
+OK and confirm it navigates to the payment status screen and polls.

--- a/docs/superpowers/specs/2026-06-19-post-otp-status-navigation-design.md
+++ b/docs/superpowers/specs/2026-06-19-post-otp-status-navigation-design.md
@@ -1,0 +1,117 @@
+# Post-OTP → Payment Status Navigation — Design
+
+**Date:** 2026-06-19
+**Branch:** keyboard-fix
+**Status:** Approved (design)
+
+## Problem
+
+After a successful OTP verification on the active (post-payment) checkout path,
+the flow dead-ends on the home screen instead of proceeding to the payment
+status screen. PM feedback: after OTP success the flow must reach the
+check-status screen.
+
+## Investigation summary
+
+`PayOrderScreen` has two OTP entry points:
+
+- **Entry A — `handleOtpFlow`** (pre-payment OTP): gated on
+  `businessInfoUiState.data?.requireMobileMoneyOtp == true`. This flag is
+  `false` for the current merchant, so the path is **dormant**. It is also
+  broken as written (pushes the OTP screen with empty
+  `clientReference`/`preApprovalId` because checkout has not run yet, and does
+  not check the `sendOtpToUser` result). **Out of scope** — see Follow-up.
+
+- **Entry B — post-payment OTP** (the active, working path): the payment
+  endpoint (`payOrder`) runs during the `CHECKOUT` step. The checkout response
+  carries `CheckoutInfo.skipOtp`. At `PAYMENT_COMPLETED`, when
+  `checkoutUiState.data?.skipOtp == false`, the app pushes `OtpVerifyScreen`
+  (PayOrderScreen.kt:841-858) with **`onFinish = { }` (empty)**. On OTP success
+  the screen calls `onFinish()` then `navigator.pop()` back to home, and nothing
+  navigates to the status screen. This empty `onFinish` is the bug.
+
+## Decision
+
+Payment is already submitted before the OTP on Entry B, so on OTP success the
+app navigates directly to `PaymentStatusScreen` (which polls/checks transaction
+status). No additional payment call is made after OTP.
+
+## Constraint that shapes the implementation
+
+`OtpVerifyScreen` runs `onFinish()` **then** `navigator.pop()`. Pushing
+`PaymentStatusScreen` directly inside `onFinish` would be undone by the
+subsequent `pop()`. The codebase already solves this for Entry A: `onFinish`
+sets a `rememberSaveable` state, the OTP screen pops, and a `LaunchedEffect` on
+the home screen reacts after it becomes visible again. We follow the same
+pattern. A plain `remember` boolean is insufficient because Voyager disposes the
+home screen's composition while the OTP screen is on top; the flag must be
+`rememberSaveable` to survive that disposal.
+
+## Changes (all in `PayOrderScreen.kt`)
+
+1. **Add a saveable flag** alongside the other screen state (near the other
+   `remember`/`rememberSaveable` declarations, ~line 161-208):
+
+   ```kotlin
+   var navigateToStatusAfterOtp by rememberSaveable { mutableStateOf(false) }
+   ```
+
+2. **Set the flag from the post-payment OTP `onFinish`** (PayOrderScreen.kt:853),
+   replacing the empty lambda:
+
+   ```kotlin
+   onFinish = {
+       navigateToStatusAfterOtp = true
+   },
+   ```
+
+3. **Add a `LaunchedEffect`** (near the other `LaunchedEffect` blocks in
+   `PayOrderScreenContent`) that navigates once the flag is set, then resets it:
+
+   ```kotlin
+   LaunchedEffect(navigateToStatusAfterOtp) {
+       if (navigateToStatusAfterOtp) {
+           navigateToStatusAfterOtp = false
+           navigator?.push(
+               PaymentStatusScreen(
+                   providerName = paymentInfo?.providerName,
+                   config = config,
+                   checkoutType = checkoutFeesUiState.data?.getCheckoutType,
+               )
+           )
+       }
+   }
+   ```
+
+   These are the same `PaymentStatusScreen` arguments the existing MoMo success
+   path already uses (e.g. PayOrderScreen.kt:566, 865). After the OTP screen pops
+   back to home, this fires and navigates. Resulting back stack:
+   `[PayOrderScreen, PaymentStatusScreen]`.
+
+## Scope boundaries
+
+- Only the post-payment OTP path (Entry B) is changed.
+- No ViewModel, API, or model changes.
+- Entry A (`handleOtpFlow`) is left untouched.
+
+## Follow-up (not in this change)
+
+Entry A is dormant and broken: if a merchant enables `requireMobileMoneyOtp`,
+its OTP would verify against an empty `clientReference`/`preApprovalId` and
+likely fail, and it pushes the OTP screen without checking the `sendOtpToUser`
+result. Flag to backend/PM; address separately if that flag will be enabled.
+
+## Risks / edge cases
+
+- **Double navigation:** guarded by resetting `navigateToStatusAfterOtp = false`
+  inside the effect before pushing, so it fires once per OTP success.
+- **OTP failure:** unchanged — `onFinish` only runs on success (the screen shows
+  its error dialog otherwise), so the flag is never set on failure.
+- **Other wallet types (bank card, bank pay):** unaffected — they have their own
+  `PAYMENT_COMPLETED` navigation branches and do not use this OTP path.
+
+## Testing
+
+Consistent with this branch: compile gate plus on-device E2E — complete a MoMo
+payment for a merchant whose checkout response returns `skipOtp == false`, enter
+the OTP, and confirm the app navigates to `PaymentStatusScreen`.


### PR DESCRIPTION
Device-verified and PM-confirmed. Changes:

- **Keyboard:** root IME inset handling in `BaseActivity` (`setDecorFitsSystemWindows(false)` + `windowInsetsPadding(systemBars ∪ ime)`) so content pushes above the soft keyboard (iOS-like) on all input screens.
- **OTP dial-shortcode:** tappable "Didn't receive the code? Dial *713*90# to view it" prompt on the verify screen (opens dialer via `ACTION_DIAL`).
- **OTP endpoint fix:** route verification to `/unifiedcheckout/verify-payment-otp` (was hitting the wrong `/verifyotp`); read success from the matching state and pass the real `requestId`.
- **Post-OTP flow:** after a successful pre-payment OTP, call `payOrder` and navigate to the payment status screen (was dead-ending on the home screen — Voyager recreates the covered screen, so the resume is driven via ViewModel state).
- **Bill-prompt dialog:** "A bill prompt has been sent to <number>. Please authorize payment." success dialog before the status screen, matching iOS.

Specs and implementation plans are under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)